### PR TITLE
Fixed errors in strings/documentation

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -521,7 +521,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
 std::string LicenseInfo()
 {
-    const std::string URL_SOURCE_CODE = "<https://github.com/HTML5/HTMLCOIN>";
+    const std::string URL_SOURCE_CODE = "<https://github.com/HTMLCOIN/HTMLCOIN>";
     const std::string URL_WEBSITE = "<https://htmlcoin.com>";
 
     return CopyrightHolders(strprintf(_("Copyright (C) %i"), COPYRIGHT_YEAR) + " ") + "\n" +

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -82,7 +82,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
     
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
         throw runtime_error(
-            "importprivkey \"htmlcoin\" ( \"label\" ) ( rescan )\n"
+            "importprivkey \"htmlcoinprivkey\" ( \"label\" ) ( rescan )\n"
             "\nAdds a private key (as returned by dumpprivkey) to your wallet.\n"
             "\nArguments:\n"
             "1. \"htmlcoinprivkey\"   (string, required) The private key (see dumpprivkey)\n"


### PR DESCRIPTION
Fixed two minor string errors:
1) When you typed `help importprivkey` in the debug console there was a mismatch between the example syntax and the 'Arguments' #1 
2) The "About" screen had the wrong Github repository address