### PR TITLE
Adding missing block template info

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -947,6 +947,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
+    result.push_back(Pair("hashStateRoot", pblock->hashStateRoot.GetHex()));
+    result.push_back(Pair("hashUTXORoot", pblock->hashUTXORoot.GetHex()));
     int64_t nSigOpLimit = dgpMaxBlockSigOps;
     if (fPreSegWit) {
         assert(nSigOpLimit % WITNESS_SCALE_FACTOR == 0);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -658,6 +658,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "     ,...\n"
             "  ],\n"
             "  \"noncerange\" : \"00000000ffffffff\",(string) A range of valid nonces\n"
+            "  \"hashstateroot\" : \"XXX\",(string) Block hash state root\n"
+            "  \"hashutxoroot\" : \"XXX\",(string) Block hash utxo root\n"
             "  \"sigoplimit\" : n,                 (numeric) limit of sigops in blocks\n"
             "  \"sizelimit\" : n,                  (numeric) limit of block size\n"
             "  \"weightlimit\" : n,                (numeric) limit of block weight\n"
@@ -947,8 +949,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("hashStateRoot", pblock->hashStateRoot.GetHex()));
-    result.push_back(Pair("hashUTXORoot", pblock->hashUTXORoot.GetHex()));
+    result.push_back(Pair("hashstateroot", pblock->hashStateRoot.GetHex()));
+    result.push_back(Pair("hashutxoroot", pblock->hashUTXORoot.GetHex()));
     int64_t nSigOpLimit = dgpMaxBlockSigOps;
     if (fPreSegWit) {
         assert(nSigOpLimit % WITNESS_SCALE_FACTOR == 0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4490,7 +4490,10 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         CValidationState state;
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
+
+        LogPrint("rpc", "ProcessNewBlock before block=%s\n", pblock->ToString());
         bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
+        LogPrint("rpc", "ProcessNewBlock new block=%s\n", pblock->ToString());
 
         LOCK(cs_main);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4491,9 +4491,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
 
-        LogPrint("rpc", "ProcessNewBlock before block=%s\n", pblock->ToString());
         bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
-        LogPrint("rpc", "ProcessNewBlock new block=%s\n", pblock->ToString());
 
         LOCK(cs_main);
 


### PR DESCRIPTION
This 2 info is missing on the getblocktemplate method.

This is needed to build correct the block header with 181 bytes.

Would be awesome if you could document the block header and body (as we know many changes have to be done to merge POW + POS) 