### PR TITLE
Update to show a message with low balance

### DIFF
--- a/src/qt/sendtokenpage.cpp
+++ b/src/qt/sendtokenpage.cpp
@@ -207,8 +207,19 @@ void SendTokenPage::on_confirmClicked()
     }
     else
     {
-        QString message = tr("To send %1 you need HTML on address <br /> %2.")
-                .arg(QString::fromStdString(m_selectedToken->symbol)).arg(QString::fromStdString(CBitcoinAddress(m_selectedToken->sender).ToString()));
+        
+        uint64_t gasLimit = ui->lineEditGasLimit->value(); //What is the gas limit?
+        long double gasPrice = ui->lineEditGasPrice->value(); //How much gas the user had defined?
+        long double calcGas = gasPrice * gasLimit; //calculate the cost of Gas 
+        long double precisionHTML = 0.00000001 * calcGas; //Do the precision to make the calculations of precision HTMLCOIN style
+        
+        /* 
+        
+        Show a message with amount of HTML needed, dinamically change when increase the gasPrice
+        The old message had no control about!
+        */ 
+        QString message = tr("To send %1 you need %2 HTML on address <br /> %3.")
+                .arg(QString::fromStdString(m_selectedToken->symbol)).arg(QString::number(precisionHTML, 'prec', 8)).arg(QString::fromStdString(CBitcoinAddress(m_selectedToken->sender).ToString()));
 
         QMessageBox::warning(this, tr("Send token"), message);
     }


### PR DESCRIPTION
Show a message to the user if he have no balance to pay GAS cost to send tokens.

The solution was create a condition that check if user have balance and if he have no balance will return a message that he need HTML and show the address that need HTML.
The message show how much HTML he need to pay the gas cost based on the price that he choosed for the gas price.

We had only one file afected by this update, it’s located at SRC/QT folder and the name of the file is: sendtokenpage.cpp 

Lines from 208 to 226.

![photo1](https://user-images.githubusercontent.com/3827247/43668414-3426f062-9753-11e8-9933-5b07533ab205.png)
![photo2](https://user-images.githubusercontent.com/3827247/43668415-344e23d0-9753-11e8-9dd7-2fda51bea1ff.png)
![photo3](https://user-images.githubusercontent.com/3827247/43668416-34772550-9753-11e8-9677-1151931ddaf0.png)
![captura de tela de 2018-08-03 19-13-21](https://user-images.githubusercontent.com/3827247/43668420-3af394b8-9753-11e8-93a2-ef9c99c4a240.png)
![captura de tela de 2018-08-03 19-13-45](https://user-images.githubusercontent.com/3827247/43668422-3b184efc-9753-11e8-8136-ae469d9b1df0.png)
